### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/qwc-config-db.yml
+++ b/.github/workflows/qwc-config-db.yml
@@ -20,7 +20,7 @@ jobs:
           fi
 
       - name: Build and publish docker image
-        uses: elgohr/Publish-Docker-Github-Action@2.12
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: sourcepole/qwc-config-db
           username: ${{ secrets.DOCKER_HUB_USER }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore